### PR TITLE
Nullable User.ConfirmedAt

### DIFF
--- a/src/Plex.Api/Models/User.cs
+++ b/src/Plex.Api/Models/User.cs
@@ -65,7 +65,7 @@ namespace Plex.Api.Models
         [JsonPropertyName("authentication_token")]
         public string AuthenticationToken { get; set; }
         
-        public DateTime ConfirmedAt { get; set; }
+        public DateTime? ConfirmedAt { get; set; }
         
         public int? ForumId { get; set; }
         


### PR DESCRIPTION
> The JSON value could not be converted to System.DateTime. Path: $.user.confirmedAt | LineNumber: 0 | BytePositionInLine: 1107.

newly created accounts that have not yet been confirmed do not have a confirmation date.