### PR TITLE
Added CreatedAt to model MediaContainer

### DIFF
--- a/src/Plex.Api/Models/MediaContainer.cs
+++ b/src/Plex.Api/Models/MediaContainer.cs
@@ -92,6 +92,7 @@ namespace Plex.Api.Models
         public string TranscoderVideoQualities { get; set; }
         public string TranscoderVideoResolutions { get; set; }
         public int UpdatedAt { get; set; }
+        public int CreatedAt { get; set; }
         public bool Updater { get; set; }
         public string Version { get; set; }
         public bool VoiceSearch { get; set; }


### PR DESCRIPTION
The MediaContainer model was missing the CreatedAt which I have added. 

Also, I have noticed that all DateTime object in the models are integers, such as UpdatedAt or CreatedAt. I believe it would be safer to have them each as a long since I have come across some misconfigured servers which return values such as "2247395385730901353". 

What are your thoughts on that?