### PR TITLE
Adds missing userRating to Metadata

### DIFF
--- a/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
@@ -36,6 +36,9 @@ namespace Plex.ServerApi.PlexModels.Media
         [JsonPropertyName("parentIndex")]
         public int ParentIndex { get; set; }
 
+        [JsonPropertyName("userRating")]
+        public double UserRating { get; set; }
+        
         [JsonPropertyName("parentThumb")]
         public string ParentThumb { get; set; }
 


### PR DESCRIPTION
Adds a Property `UserRating` to the class `Metadata` to hold data from the XML-Field `userRating`.
