### PR TITLE
Add accountId param to GetPlayHistory

### DIFF
--- a/Source/Plex.Library/ApiModels/Servers/Server.cs
+++ b/Source/Plex.Library/ApiModels/Servers/Server.cs
@@ -522,9 +522,10 @@ namespace Plex.Library.ApiModels.Servers
         /// <param name="start">Starting record</param>
         /// <param name="count">Only return the specified number of results (optional)</param>
         /// <param name="minDate">Min datetime to return results from.</param>
+        /// <param name="accountId">Account id to return results from.</param>
         /// <returns></returns>
-        public async Task<HistoryMediaContainer> PlayHistory(int start = 0, int count = 100, DateTime? minDate = null) =>
-            await this.plexServerClient.GetPlayHistory(this.AccessToken, this.Uri.ToString(), start, count, minDate);
+        public async Task<HistoryMediaContainer> PlayHistory(int start = 0, int count = 100, DateTime? minDate = null, int? accountId = null) =>
+            await this.plexServerClient.GetPlayHistory(this.AccessToken, this.Uri.ToString(), start, count, minDate, accountId);
 
         /// <summary>
         /// Get Devices connected to this Server

--- a/Source/Plex.ServerApi/Clients/Interfaces/IPlexServerClient.cs
+++ b/Source/Plex.ServerApi/Clients/Interfaces/IPlexServerClient.cs
@@ -181,8 +181,9 @@ namespace Plex.ServerApi.Clients.Interfaces
         /// <param name="start">Starting Record</param>
         /// <param name="count">Count of Records</param>
         /// <param name="minDate">Starting Date</param>
+        /// <param name="accountId">Account Identifier</param>
         /// <returns>MediaContainer</returns>
-        Task<HistoryMediaContainer> GetPlayHistory(string authToken, string plexServerHost, int start = 0, int count = 100, DateTime? minDate = null);
+        Task<HistoryMediaContainer> GetPlayHistory(string authToken, string plexServerHost, int start = 0, int count = 100, DateTime? minDate = null, int? accountId = null);
 
         /// <summary>
         /// Get Clients connected to a given Server

--- a/Source/Plex.ServerApi/Clients/PlexServerClient.cs
+++ b/Source/Plex.ServerApi/Clients/PlexServerClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Plex.ServerApi.Clients
+namespace Plex.ServerApi.Clients
 {
     using System;
     using System.Collections.Generic;
@@ -278,12 +278,24 @@
 
         /// <inheritdoc/>
         public async Task<HistoryMediaContainer> GetPlayHistory(string authToken, string plexServerHost, int start = 0,
-            int count = 100, DateTime? minDate = null)
+            int count = 100, DateTime? minDate = null, int? accountId = null)
         {
             var queryParams = new Dictionary<string, string>
             {
                 { "X-Plex-Container-Start", start.ToString() }, { "X-Plex-Container-Size", count.ToString() }
             };
+
+            if (minDate != null)
+            {
+                var dateTimeOffset = new DateTimeOffset(minDate.Value);
+                var unixMinDate = dateTimeOffset.ToUnixTimeSeconds();
+                queryParams.Add("viewedAt>", unixMinDate.ToString());
+            }
+
+            if (accountId != null)
+            {
+                queryParams.Add("accountID", accountId.ToString());
+            }
 
             return await this.FetchWithWrapper<HistoryMediaContainer>(plexServerHost, "status/sessions/history/all",
                 authToken, HttpMethod.Get, queryParams);

--- a/Source/Plex.ServerApi/PlexModels/Server/History/HistoryMetadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/History/HistoryMetadata.cs
@@ -30,5 +30,11 @@ namespace Plex.ServerApi.PlexModels.Server.History
 
         [JsonPropertyName("accountID")]
         public int AccountId { get; set; }
+
+        [JsonPropertyName("parentKey")]
+        public string ParentKey { get; set; }
+
+        [JsonPropertyName("grandparentKey")]
+        public string GrandParentKey { get; set; }
     }
 }


### PR DESCRIPTION
This add :

- a new filter to `GetPlayHistory` to search by `accountId`
- a fix to `minDate` param usage on `GetPlayHistory`
- Add two field in `HistoryMetada`  for episode type