### PR TITLE
Fix unit tests running for ServerApiTest on Visual Studio

### DIFF
--- a/Tests/Plex.ServerApi.Test/Plex.ServerApi.Test.csproj
+++ b/Tests/Plex.ServerApi.Test/Plex.ServerApi.Test.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Units tests on ServerApi.Test won't run on Visual Studio unless addind `xunit.runner.visualstudio` is added like in Plex.Library.Test