### PR TITLE
Get Plex Home User account added

### DIFF
--- a/Source/Plex.Library/ApiModels/Accounts/PlexAccount.cs
+++ b/Source/Plex.Library/ApiModels/Accounts/PlexAccount.cs
@@ -116,7 +116,7 @@ namespace Plex.Library.ApiModels.Accounts
         public bool HomeAdmin { get; set; }
         public int MaxHomeSize { get; set; }
         public int CertificateVersion { get; set; }
-        public DateTime RememberExpiresAt { get; set; }
+        public DateTime? RememberExpiresAt { get; set; }
         public object AdsConsent { get; set; }
         public object AdsConsentSetAt { get; set; }
         public object AdsConsentReminderAt { get; set; }
@@ -210,6 +210,26 @@ namespace Plex.Library.ApiModels.Accounts
         /// <returns>UserContainer Object</returns>
         public async Task<UserContainer> Users() =>
             await this.plexAccountClient.GetUsers(this.AuthToken);
+
+
+
+        /// <summary>
+        /// Returns a list of all User objects connected to your account.
+        /// This includes both friends and pending invites. You can reference the user.Friend to
+        /// distinguish between the two.
+        /// </summary>
+        /// <returns>UserContainer Object</returns>
+        public async Task<PlexAccount> GetPlexHomeAccountAsync(string userUUID)
+        {
+            var account = await this.plexAccountClient.GetPlexHomeAccountAsync(this.AuthToken, userUUID);
+            if (account == null)
+            {
+                return null;
+            }
+
+            return new PlexAccount(this.plexAccountClient, this.plexServerClient, this.plexLibraryClient, account.AuthToken);
+        }
+
 
         /// <summary>
         /// Opt in or out of sharing stuff with plex.

--- a/Source/Plex.Library/Automapper/PlexAccountModelMapper.cs
+++ b/Source/Plex.Library/Automapper/PlexAccountModelMapper.cs
@@ -18,7 +18,7 @@ namespace Plex.Library.Automapper
             this.CreateMap<ServerApi.PlexModels.Account.PlexAccount, PlexAccount>()
                 .ForMember(x => x.RememberExpiresAt,
                     opt =>
-                        opt.MapFrom(src => DateTimeOffset.FromUnixTimeSeconds(src.RememberExpiresAt).UtcDateTime));
+                        opt.MapFrom(src => src.RememberExpiresAt.HasValue?DateTimeOffset.FromUnixTimeSeconds(src.RememberExpiresAt.Value).UtcDateTime:(DateTime?)null));
         }
     }
 }

--- a/Source/Plex.ServerApi/Clients/Interfaces/IPlexAccountClient.cs
+++ b/Source/Plex.ServerApi/Clients/Interfaces/IPlexAccountClient.cs
@@ -115,5 +115,14 @@ namespace Plex.ServerApi.Clients.Interfaces
         /// <param name="pinCode"></param>
         /// <returns></returns>
         Task<object> LinkDeviceToAccountByPin(string pinCode);
+
+
+        /// <summary>
+        /// Switch to the account of another Home User
+        /// </summary>
+        /// <param name="authToken">Authentication Token.</param>
+        /// <param name="userUUID">UUID of the home user to switch to.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<PlexModels.Account.PlexAccount> GetPlexHomeAccountAsync(string authToken, string userUUID);
     }
 }

--- a/Source/Plex.ServerApi/Clients/PlexAccountClient.cs
+++ b/Source/Plex.ServerApi/Clients/PlexAccountClient.cs
@@ -103,6 +103,28 @@ namespace Plex.ServerApi.Clients
         }
 
         /// <inheritdoc/>
+        public async Task<PlexModels.Account.PlexAccount> GetPlexHomeAccountAsync(string authToken, string userUUID)
+        {
+
+            var apiRequest =
+                new ApiRequestBuilder($"https://plex.tv/api/v2/home/users/{userUUID}/switch.json", string.Empty, HttpMethod.Post)
+                    .AddRequestHeaders(ClientUtilities.GetClientIdentifierHeader(this.clientOptions.ClientId))
+                    .AddRequestHeaders(ClientUtilities.GetClientMetaHeaders(this.clientOptions))
+                    .AddPlexToken(authToken)
+                    .AcceptJson()
+                    .Build();
+
+            var account = await this.apiService.InvokeApiAsync<PlexModels.Account.PlexAccount>(apiRequest);
+
+            if (account == null)
+            {
+                throw new ApplicationException("Switching User failed.");
+            }
+
+            return account;
+        }
+
+        /// <inheritdoc/>
         public async Task<PlexModels.Account.PlexAccount> GetPlexAccountAsync(string authToken)
         {
             var apiRequest = new ApiRequestBuilder(BaseUri + "user.json", string.Empty, HttpMethod.Get)

--- a/Source/Plex.ServerApi/PlexModels/Account/PlexAccount.cs
+++ b/Source/Plex.ServerApi/PlexModels/Account/PlexAccount.cs
@@ -84,7 +84,7 @@ namespace Plex.ServerApi.PlexModels.Account
         public int CertificateVersion { get; set; }
 
         [JsonPropertyName("rememberExpiresAt")]
-        public long RememberExpiresAt { get; set; }
+        public long? RememberExpiresAt { get; set; }
 
         [JsonPropertyName("adsConsent")]
         public object AdsConsent { get; set; }

--- a/Tests/Plex.ServerApi.Test/Tests/AccountTest.cs
+++ b/Tests/Plex.ServerApi.Test/Tests/AccountTest.cs
@@ -1,6 +1,7 @@
 namespace Plex.ServerApi.Test.Tests
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using Clients.Interfaces;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
@@ -23,6 +24,19 @@ namespace Plex.ServerApi.Test.Tests
             var plexAccount = this.fixture.PlexFactory.GetPlexAccount(this.fixture.TestConfiguration.AccessToken);
             Assert.NotNull(plexAccount);
         }
+
+        [Fact]
+        public async Task Test_GetPlexHomeAccountAsync()
+        {
+            var plexAccount = this.fixture.PlexFactory.GetPlexAccount(this.fixture.TestConfiguration.AccessToken);
+            var user = (await plexAccount.Friends()).FirstOrDefault(x => x.Home);
+            Assert.NotNull(user);
+            var homeAccount = await plexAccount.GetPlexHomeAccountAsync(user.Uuid);
+            Assert.NotNull(homeAccount);
+            Assert.NotEqual(plexAccount.AuthToken, homeAccount.AuthToken);
+            Assert.NotEqual(plexAccount.Title, homeAccount.Title);
+        }
+
 
         [Fact]
         public void Test_GetPlexAccount()


### PR DESCRIPTION
Added support for changing to a Home user account and a test for it.
I also had to make RememberExpiresAt nullable since it is null on the Home user accounts
