### PR TITLE
Fix missing ScrapingIds on Seasons and episodes

### DIFF
--- a/Source/Plex.ServerApi/Clients/PlexServerClient.cs
+++ b/Source/Plex.ServerApi/Clients/PlexServerClient.cs
@@ -194,6 +194,7 @@ namespace Plex.ServerApi.Clients
                 { "includeExtras", "1" },
                 { "includeStations", "1" },
                 { "includeChapters", "1" },
+                { "includeGuids", "1" }
             };
 
             // var apiRequest =


### PR DESCRIPTION
Fixes the missing ScrapingIds on season and episodes
