### PR TITLE
Added LeafCount, ChildCount and ViewedLeafCount and a test

### DIFF
--- a/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
@@ -83,8 +83,17 @@ namespace Plex.ServerApi.PlexModels.Media
         [JsonPropertyName("audienceRating")]
         public double AudienceRating { get; set; }
 
+        [JsonPropertyName("leafCount")]
+        public int LeafCount { get; set; }
+
+        [JsonPropertyName("childCount")]
+        public int ChildCount { get; set; }
+
         [JsonPropertyName("viewCount")]
         public int ViewCount { get; set; }
+
+        [JsonPropertyName("viewedLeafCount")]
+        public int ViewedLeafCount { get; set; }
 
         [JsonPropertyName("lastViewedAt")]
         public long LastViewedAt { get; set; }

--- a/Tests/Plex.ServerApi.Test/Tests/TvLibraryTest.cs
+++ b/Tests/Plex.ServerApi.Test/Tests/TvLibraryTest.cs
@@ -17,6 +17,29 @@ public class TvLibraryTest : IClassFixture<PlexFixture>
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task Test_GetShows()
+        {
+            var library = this.fixture.Server.Libraries().Result.Single(c => c.Title == "TV Shows") as ShowLibrary;
+            Assert.NotNull(library);
+
+
+            var shows = await library.AllShows("");
+            Assert.NotNull(shows);
+            Assert.True(shows.Media.Count > 0);
+
+            var show = shows.Media.First();
+            Assert.NotNull(show);
+
+            Assert.True(show.ChildCount > 0);
+            Assert.True(show.LeafCount > 0);
+            if (show.ViewCount > 0)
+            {
+                Assert.True(show.ViewedLeafCount > 0);
+            }
+        }
+
+
+        [Fact]
         public async System.Threading.Tasks.Task Test_GetSeasonsForShow()
         {
             var library = this.fixture.Server.Libraries().Result.Single(c => c.Title == "TV Shows") as ShowLibrary;


### PR DESCRIPTION
Hoping this can be merged in as i have just added the counts so you can see how many seasons, episodes etc a show/season has.

I need this to detect changes when the update date has not changed but an episode was added. In reality it should not happen but i now have had it happen 4 times.
