### PR TITLE
Include ipv6 addresses in resource connections

### DIFF
--- a/Source/Plex.ServerApi/Clients/PlexAccountClient.cs
+++ b/Source/Plex.ServerApi/Clients/PlexAccountClient.cs
@@ -160,7 +160,7 @@ public class PlexAccountClient : IPlexAccountClient
     {
         var queryParams = new Dictionary<string, string>
         {
-            {"includeHttps", "1"}, {"includeRelay", "1"}
+            {"includeHttps", "1"}, {"includeRelay", "1"}, {"includeIPv6", "1"}
         };
 
         var apiRequest = new ApiRequestBuilder(BaseUri + "resources", "", HttpMethod.Get)


### PR DESCRIPTION
While trying to access my servers with plex-api, I wondered why I couldn't reach all. So I compared the api call with the request in browser when opening https://app.plex.tv/desktop/#!/ and found the difference:
Query parameter &includeIpv6=1 is missing, so it won't return ipv6 addresses. I added it to GetResourcesAsync().