### PR TITLE
Added missing parentRatingKey in Metadata model class

### DIFF
--- a/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Media/Metadata.cs
@@ -33,12 +33,15 @@ namespace Plex.ServerApi.PlexModels.Media
         [JsonPropertyName("parentGuid")]
         public string ParentGuid { get; set; }
 
+        [JsonPropertyName("parentRatingKey")]
+        public string ParentRatingKey { get; set; }
+
         [JsonPropertyName("parentIndex")]
         public int ParentIndex { get; set; }
 
         [JsonPropertyName("userRating")]
         public double UserRating { get; set; }
-        
+
         [JsonPropertyName("parentThumb")]
         public string ParentThumb { get; set; }
 


### PR DESCRIPTION
Hi, once again a small change pr:
The property parentRatingKey was missing in class Metadata - whereas ratingKey and grandparentRatingKey exist already.

Now you can link e.g. a track to its album by their unique RatingKey.