### PR TITLE
fixed type error in SessionMetadata.cs on AddedAt (string to long)

### DIFF
--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/SessionMetadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/SessionMetadata.cs
@@ -7,7 +7,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
     public class SessionMetadata
     {
         [JsonPropertyName("addedAt")]
-        public string AddedAt { get; set; }
+        public long AddedAt { get; set; }
 
         [JsonPropertyName("art")]
         public string Art { get; set; }


### PR DESCRIPTION
I could reproduce with the tests the issue mentioned in #82. Here is a simple fix which validates the tests.