### PR TITLE
More fixes GetSessions & GetTranscodeSessions

### DIFF
--- a/Source/Plex.ServerApi/PlexModels/Server/Playlists/TranscodeSession.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Playlists/TranscodeSession.cs
@@ -14,7 +14,7 @@ namespace Plex.ServerApi.PlexModels.Server.Playlists
         public bool Complete { get; set; }
 
         [JsonPropertyName("progress")]
-        public string Progress { get; set; }
+        public double Progress { get; set; }
 
         [JsonPropertyName("size")]
         public int Size { get; set; }

--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/Medium.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/Medium.cs
@@ -9,22 +9,22 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string AspectRatio { get; set; }
 
         [JsonPropertyName("audioChannels")]
-        public string AudioChannels { get; set; }
+        public int AudioChannels { get; set; }
 
         [JsonPropertyName("audioCodec")]
         public string AudioCodec { get; set; }
 
         [JsonPropertyName("bitrate")]
-        public string Bitrate { get; set; }
+        public int Bitrate { get; set; }
 
         [JsonPropertyName("container")]
         public string Container { get; set; }
 
         [JsonPropertyName("duration")]
-        public string Duration { get; set; }
+        public int Duration { get; set; }
 
         [JsonPropertyName("height")]
-        public string Height { get; set; }
+        public int Height { get; set; }
 
         [JsonPropertyName("id")]
         public string Id { get; set; }
@@ -42,7 +42,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string VideoResolution { get; set; }
 
         [JsonPropertyName("width")]
-        public string Width { get; set; }
+        public int Width { get; set; }
 
         [JsonPropertyName("selected")]
         public bool Selected { get; set; }
@@ -54,7 +54,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string AudioProfile { get; set; }
 
         [JsonPropertyName("optimizedForStreaming")]
-        public string OptimizedForStreaming { get; set; }
+        public bool OptimizedForStreaming { get; set; }
 
         [JsonPropertyName("protocol")]
         public string Protocol { get; set; }

--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/Part.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/Part.cs
@@ -9,7 +9,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string Container { get; set; }
 
         [JsonPropertyName("duration")]
-        public string Duration { get; set; }
+        public long Duration { get; set; }
 
         [JsonPropertyName("file")]
         public string File { get; set; }
@@ -21,7 +21,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string Key { get; set; }
 
         [JsonPropertyName("size")]
-        public string Size { get; set; }
+        public int Size { get; set; }
 
         [JsonPropertyName("videoProfile")]
         public string VideoProfile { get; set; }
@@ -39,18 +39,18 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string AudioProfile { get; set; }
 
         [JsonPropertyName("bitrate")]
-        public string Bitrate { get; set; }
+        public int Bitrate { get; set; }
 
         [JsonPropertyName("height")]
-        public string Height { get; set; }
+        public int Height { get; set; }
 
         [JsonPropertyName("optimizedForStreaming")]
-        public string OptimizedForStreaming { get; set; }
+        public bool OptimizedForStreaming { get; set; }
 
         [JsonPropertyName("protocol")]
         public string Protocol { get; set; }
 
         [JsonPropertyName("width")]
-        public string Width { get; set; }
+        public int Width { get; set; }
     }
 }

--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/SessionMetadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/SessionMetadata.cs
@@ -22,7 +22,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string ContentRating { get; set; }
 
         [JsonPropertyName("duration")]
-        public string Duration { get; set; }
+        public long Duration { get; set; }
 
         [JsonPropertyName("grandparentArt")]
         public string GrandparentArt { get; set; }
@@ -49,7 +49,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string Guid { get; set; }
 
         [JsonPropertyName("index")]
-        public string Index { get; set; }
+        public int Index { get; set; }
 
         [JsonPropertyName("key")]
         public string Key { get; set; }
@@ -70,7 +70,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string ParentGuid { get; set; }
 
         [JsonPropertyName("parentIndex")]
-        public string ParentIndex { get; set; }
+        public int ParentIndex { get; set; }
 
         [JsonPropertyName("parentKey")]
         public string ParentKey { get; set; }
@@ -112,10 +112,10 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string Type { get; set; }
 
         [JsonPropertyName("updatedAt")]
-        public string UpdatedAt { get; set; }
+        public long UpdatedAt { get; set; }
 
         [JsonPropertyName("viewOffset")]
-        public string ViewOffset { get; set; }
+        public long ViewOffset { get; set; }
 
         [JsonPropertyName("year")]
         public string Year { get; set; }
@@ -136,7 +136,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string ChapterSource { get; set; }
 
         [JsonPropertyName("lastViewedAt")]
-        public string LastViewedAt { get; set; }
+        public long LastViewedAt { get; set; }
 
         [JsonPropertyName("titleSort")]
         public string TitleSort { get; set; }

--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/Stream.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/Stream.cs
@@ -5,10 +5,10 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
     public class Stream
     {
         [JsonPropertyName("bitDepth")]
-        public string BitDepth { get; set; }
+        public int BitDepth { get; set; }
 
         [JsonPropertyName("bitrate")]
-        public string Bitrate { get; set; }
+        public long Bitrate { get; set; }
 
         [JsonPropertyName("chromaLocation")]
         public string ChromaLocation { get; set; }
@@ -20,7 +20,7 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string Codec { get; set; }
 
         [JsonPropertyName("default")]
-        public string Default { get; set; }
+        public bool Default { get; set; }
 
         [JsonPropertyName("displayTitle")]
         public string DisplayTitle { get; set; }
@@ -29,19 +29,19 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string ExtendedDisplayTitle { get; set; }
 
         [JsonPropertyName("frameRate")]
-        public string FrameRate { get; set; }
+        public float FrameRate { get; set; }
 
         [JsonPropertyName("hasScalingMatrix")]
         public string HasScalingMatrix { get; set; }
 
         [JsonPropertyName("height")]
-        public string Height { get; set; }
+        public int Height { get; set; }
 
         [JsonPropertyName("id")]
         public string Id { get; set; }
 
         [JsonPropertyName("index")]
-        public string Index { get; set; }
+        public int Index { get; set; }
 
         [JsonPropertyName("language")]
         public string Language { get; set; }
@@ -62,10 +62,10 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string ScanType { get; set; }
 
         [JsonPropertyName("streamType")]
-        public string StreamType { get; set; }
+        public int StreamType { get; set; }
 
         [JsonPropertyName("width")]
-        public string Width { get; set; }
+        public int Width { get; set; }
 
         [JsonPropertyName("location")]
         public string Location { get; set; }
@@ -74,13 +74,13 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public string AudioChannelLayout { get; set; }
 
         [JsonPropertyName("channels")]
-        public string Channels { get; set; }
+        public int Channels { get; set; }
 
         [JsonPropertyName("samplingRate")]
-        public string SamplingRate { get; set; }
+        public long SamplingRate { get; set; }
 
         [JsonPropertyName("selected")]
-        public string Selected { get; set; }
+        public bool Selected { get; set; }
 
         [JsonPropertyName("decision")]
         public string Decision { get; set; }

--- a/Source/Plex.ServerApi/PlexModels/Server/Sessions/TranscodeSession.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Sessions/TranscodeSession.cs
@@ -14,13 +14,13 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public bool Complete { get; set; }
 
         [JsonPropertyName("progress")]
-        public string Progress { get; set; }
+        public double Progress { get; set; }
 
         [JsonPropertyName("size")]
         public int Size { get; set; }
 
         [JsonPropertyName("speed")]
-        public string Speed { get; set; }
+        public float Speed { get; set; }
 
         [JsonPropertyName("duration")]
         public int Duration { get; set; }
@@ -65,12 +65,12 @@ namespace Plex.ServerApi.PlexModels.Server.Sessions
         public bool TranscodeHwFullPipeline { get; set; }
 
         [JsonPropertyName("timeStamp")]
-        public string TimeStamp { get; set; }
+        public double TimeStamp { get; set; }
 
         [JsonPropertyName("maxOffsetAvailable")]
-        public string MaxOffsetAvailable { get; set; }
+        public double MaxOffsetAvailable { get; set; }
 
         [JsonPropertyName("minOffsetAvailable")]
-        public string MinOffsetAvailable { get; set; }
+        public double MinOffsetAvailable { get; set; }
     }
 }

--- a/Source/Plex.ServerApi/PlexModels/Server/Transcoders/TranscodeSession.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Transcoders/TranscodeSession.cs
@@ -14,13 +14,13 @@ namespace Plex.ServerApi.PlexModels.Server.Transcoders
         public bool Complete { get; set; }
 
         [JsonPropertyName("progress")]
-        public string Progress { get; set; }
+        public double Progress { get; set; }
 
         [JsonPropertyName("size")]
         public int Size { get; set; }
 
         [JsonPropertyName("speed")]
-        public string Speed { get; set; }
+        public float Speed { get; set; }
 
         [JsonPropertyName("duration")]
         public int Duration { get; set; }
@@ -65,12 +65,12 @@ namespace Plex.ServerApi.PlexModels.Server.Transcoders
         public bool TranscodeHwFullPipeline { get; set; }
 
         [JsonPropertyName("timeStamp")]
-        public string TimeStamp { get; set; }
+        public double TimeStamp { get; set; }
 
         [JsonPropertyName("maxOffsetAvailable")]
-        public string MaxOffsetAvailable { get; set; }
+        public double MaxOffsetAvailable { get; set; }
 
         [JsonPropertyName("minOffsetAvailable")]
-        public string MinOffsetAvailable { get; set; }
+        public double MinOffsetAvailable { get; set; }
     }
 }


### PR DESCRIPTION
I conducted more thorough testing with different kinds of sessions (audio / video / transcode / no transcode) and was able to fix quite a lot of fields whose types have been updated from string to a more appropriate type (bool / number) in PLEX's JSON API schema.