### PR TITLE
Add more support for playlists

### DIFF
--- a/Plex.Api.sln
+++ b/Plex.Api.sln
@@ -56,6 +56,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{DB90
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlexBlazorServerOAuthExample", "Samples\PlexBlazorServerOAuthExample\PlexBlazorServerOAuthExample.csproj", "{6FBB1D08-2EF6-4A6C-9BB1-4C1F9155FA97}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlexPlaylistSplitter", "Samples\PlexPlaylistSplitter\PlexPlaylistSplitter.csproj", "{B82940FD-79C5-4364-8910-B6EA4B94FFED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +84,10 @@ Global
 		{6FBB1D08-2EF6-4A6C-9BB1-4C1F9155FA97}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FBB1D08-2EF6-4A6C-9BB1-4C1F9155FA97}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FBB1D08-2EF6-4A6C-9BB1-4C1F9155FA97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B82940FD-79C5-4364-8910-B6EA4B94FFED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B82940FD-79C5-4364-8910-B6EA4B94FFED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B82940FD-79C5-4364-8910-B6EA4B94FFED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B82940FD-79C5-4364-8910-B6EA4B94FFED}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +102,7 @@ Global
 		{820AA2CC-8529-43F1-9E25-6AB53A368D1E} = {719809C2-A551-4C4A-9EFD-B10FB5E35BC0}
 		{26E41804-CA5F-4A99-993A-126287B57884} = {E1B24F25-B8A4-46EE-B7EB-7803DCFC543F}
 		{6FBB1D08-2EF6-4A6C-9BB1-4C1F9155FA97} = {DB90C6BE-7E69-4A0F-886A-5EDC88312422}
+		{B82940FD-79C5-4364-8910-B6EA4B94FFED} = {DB90C6BE-7E69-4A0F-886A-5EDC88312422}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73F36209-F8D6-4066-8951-D97729F773CF}

--- a/Samples/PlexPlaylistSplitter/.editorconfig
+++ b/Samples/PlexPlaylistSplitter/.editorconfig
@@ -1,0 +1,19 @@
+[*.cs]
+
+# IDE0065: Misplaced using directive
+csharp_using_directive_placement = outside_namespace
+
+# IDE0160: Convert to block scoped namespace
+csharp_style_namespace_declarations = file_scoped
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = none
+
+# IDE0009: Member access should be qualified.
+dotnet_style_qualification_for_field = false
+
+# CA1848: Use the LoggerMessage delegates
+dotnet_diagnostic.CA1848.severity = silent
+
+# IDE0009: Member access should be qualified.
+dotnet_style_qualification_for_method = false

--- a/Samples/PlexPlaylistSplitter/PlexPlaylistSplitter.csproj
+++ b/Samples/PlexPlaylistSplitter/PlexPlaylistSplitter.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-PlexPlaylistSplitter-8637DC77-BB07-4799-B88A-5A0CF8A80891</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Source\Plex.Library\Plex.Library.csproj" />
+    <ProjectReference Include="..\..\Source\Plex.ServerApi\Plex.ServerApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EditorConfigFiles Remove="E:\Dev\plex-api\Samples\PlexPlaylistSplitter\.editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="E:\Dev\plex-api\Samples\PlexPlaylistSplitter\.editorconfig" />
+  </ItemGroup>
+</Project>

--- a/Samples/PlexPlaylistSplitter/Program.cs
+++ b/Samples/PlexPlaylistSplitter/Program.cs
@@ -1,0 +1,37 @@
+using Plex.Api.Factories;
+using Plex.Library.Factories;
+using Plex.ServerApi;
+using Plex.ServerApi.Api;
+using Plex.ServerApi.Clients;
+using Plex.ServerApi.Clients.Interfaces;
+using PlexPlaylistSplitter;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+        services.AddHostedService<Worker>();
+        // Create Client Options
+        var apiOptions = new ClientOptions
+        {
+            Product = "API_UnitTests",
+            DeviceName = "API_UnitTests",
+            ClientId = "MyClientId",
+            Platform = "Web",
+            Version = "v1"
+        };
+
+        // Setup Dependency Injection
+        services.AddSingleton(apiOptions);
+        services.AddTransient<IPlexServerClient, PlexServerClient>();
+        services.AddTransient<IPlexAccountClient, PlexAccountClient>();
+        services.AddTransient<IPlexLibraryClient, PlexLibraryClient>();
+        services.AddTransient<IApiService, ApiService>();
+        services.AddTransient<IPlexFactory, PlexFactory>();
+        services.AddTransient<IPlexRequestsHttpClient, PlexRequestsHttpClient>();
+        services.Configure<SplitOptions>(hostContext.Configuration);
+
+
+    })
+    .Build();
+
+await host.RunAsync();

--- a/Samples/PlexPlaylistSplitter/Properties/launchSettings.json
+++ b/Samples/PlexPlaylistSplitter/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "PlexPlaylistSplitter": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Samples/PlexPlaylistSplitter/SplitOptions.cs
+++ b/Samples/PlexPlaylistSplitter/SplitOptions.cs
@@ -1,0 +1,26 @@
+namespace PlexPlaylistSplitter;
+
+public class SplitOptions
+{
+    public string? PlexToken { get; set; }
+
+    public string? PlexUsername { get; set; }
+
+    public string? PlexPassword { get; set; }
+
+    public string? PlexServerName { get; set; }
+
+    public string? PlaylistName { get; set; }
+
+    public bool SortPlaylist { get; set; } = true;
+
+    public int SplitCount { get; set; } = 250;
+
+    public int ChunkSize { get; set; } = 25;
+
+    public string PlaylistType { get; set; } = "audio";
+
+    public string? ServerHostOverride { get; set; }
+
+    public int? ServerPortOverride { get; set; }
+}

--- a/Samples/PlexPlaylistSplitter/Worker.cs
+++ b/Samples/PlexPlaylistSplitter/Worker.cs
@@ -1,0 +1,145 @@
+using Microsoft.Extensions.Options;
+using Plex.Api.Factories;
+using Plex.Library.ApiModels.Accounts;
+using Plex.Library.ApiModels.Servers;
+using Plex.ServerApi.Clients.Interfaces;
+using Plex.ServerApi.PlexModels.Media;
+using Plex.ServerApi.PlexModels.Server.Playlists;
+
+namespace PlexPlaylistSplitter;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+    private readonly IHostApplicationLifetime _lifeTime;
+    private readonly SplitOptions _splitOptions;
+    private readonly IPlexFactory _plexFactory;
+    private readonly IPlexServerClient _plexServerClient;
+    private readonly IPlexLibraryClient _plexLibraryClient;
+
+    public Worker(
+        ILogger<Worker> logger,
+        IHostApplicationLifetime lifetime,
+        IOptions<SplitOptions> options,
+        IPlexFactory plexFactory,
+        IPlexServerClient plexServerClient,
+        IPlexLibraryClient plexLibraryClient)
+    {
+        _logger = logger;
+        _lifeTime = lifetime;
+        _splitOptions = options.Value;
+        _plexFactory = plexFactory;
+        _plexServerClient = plexServerClient;
+        _plexLibraryClient = plexLibraryClient;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogDebug("Worker running at: {StartTime}", DateTimeOffset.Now);
+
+        if (string.IsNullOrEmpty(_splitOptions.PlexToken) &&
+            (string.IsNullOrEmpty(_splitOptions.PlexUsername) || string.IsNullOrEmpty(_splitOptions.PlexPassword)))
+        {
+            _logger.LogError("Either PlexToken or PlexUsername and PlexPassword must be supplied");
+            _lifeTime.StopApplication();
+            return;
+        }
+
+        if (string.IsNullOrEmpty(_splitOptions.PlaylistName))
+        {
+            _logger.LogError("PlaylistName must be supplied");
+            _lifeTime.StopApplication();
+            return;
+        }
+
+        PlexAccount account = null!;
+        if (!string.IsNullOrEmpty(_splitOptions.PlexToken))
+        {
+            account = _plexFactory.GetPlexAccount(_splitOptions.PlexToken);
+        }
+        else
+        {
+            account = _plexFactory.GetPlexAccount(_splitOptions.PlexUsername, _splitOptions.PlexPassword);
+        }
+
+        _logger.LogDebug("Successfully retrieved account {PlexAccountUuid}", account.Uuid);
+
+        var serverSummaries = await account.ServerSummaries();
+        var myServerSummary = serverSummaries.Servers
+            .FirstOrDefault(x => string.IsNullOrEmpty(_splitOptions.PlexServerName) ? x.Owned == 1 : x.Name == _splitOptions.PlexServerName);
+
+        if (myServerSummary == null)
+        {
+            _logger.LogError("No matching server found");
+            _lifeTime.StopApplication();
+            return;
+        }
+
+        myServerSummary.Host = _splitOptions.ServerHostOverride ?? myServerSummary.Host;
+        myServerSummary.Port = _splitOptions.ServerPortOverride ?? myServerSummary.Port;
+
+        var myServer = new Server(_plexServerClient, _plexLibraryClient, myServerSummary);
+
+        var playlists = await myServer.Playlists();
+
+        var sourceName = _splitOptions.PlaylistName;
+        var splitSize = _splitOptions.SplitCount;
+
+        var sourcePlaylist = playlists.Metadata.Single(x => x.Title == sourceName);
+
+        var sourceItems = await myServer.GetPlaylistItems(sourcePlaylist);
+
+        var metadata = sourceItems.Media;
+        if (_splitOptions.SortPlaylist)
+        {
+            metadata = metadata.OrderBy(item => item.Media[0].Part[0].File).ToList();
+        }
+
+        var processedSplits = 0;
+        var accumulatedMetadata = new List<Metadata>();
+
+        var totalSplits = (int)Math.Ceiling(metadata.Count / (double)splitSize);
+
+        foreach (var item in metadata)
+        {
+            if (accumulatedMetadata.Count == splitSize)
+            {
+                processedSplits++;
+                await CreatePlaylistAsync(myServer, sourceName, processedSplits, totalSplits, accumulatedMetadata, stoppingToken);
+                accumulatedMetadata.Clear();
+            }
+            accumulatedMetadata.Add(item);
+        }
+
+        if (accumulatedMetadata.Count != 0)
+        {
+            processedSplits++;
+            await CreatePlaylistAsync(myServer, sourceName, processedSplits, totalSplits, accumulatedMetadata, stoppingToken);
+            accumulatedMetadata.Clear();
+        }
+
+        _logger.LogInformation("Created {TotalSplits} playlists for {ItemCount} items", totalSplits, metadata.Count);
+        _lifeTime.StopApplication();
+    }
+
+    private async Task CreatePlaylistAsync(Server myServer, string sourceName, int processedSplits, int totalSplits, List<Metadata> accumulatedMetadata, CancellationToken stoppingToken)
+    {
+        var chunkSize = _splitOptions.ChunkSize;
+        var playlistType = _splitOptions.PlaylistType;
+
+        var chunks = accumulatedMetadata.Select(x => x.RatingKey).Chunk(chunkSize);
+        PlaylistMetadata? metadata = null;
+        foreach (var chunk in chunks)
+        {
+            if (metadata == null)
+            {
+                var playlistContainer = await myServer.CreatePlaylist($"{sourceName} Split {processedSplits} of {totalSplits}", playlistType, chunk);
+                metadata = playlistContainer.Metadata.First();
+            }
+            else
+            {
+                await myServer.AddPlaylistItems(metadata, chunk);
+            }
+        }
+    }
+}

--- a/Samples/PlexPlaylistSplitter/appsettings.Development.json
+++ b/Samples/PlexPlaylistSplitter/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Samples/PlexPlaylistSplitter/appsettings.json
+++ b/Samples/PlexPlaylistSplitter/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Source/Plex.Library/ApiModels/Servers/Server.cs
+++ b/Source/Plex.Library/ApiModels/Servers/Server.cs
@@ -630,6 +630,33 @@ namespace Plex.Library.ApiModels.Servers
             await this.plexServerClient.GetPlaylists(this.AccessToken, this.Uri.ToString());
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="title"></param>
+        /// <param name="listType"></param>
+        /// <param name="itemRatingKeys"></param>
+        /// <returns></returns>
+        public async Task<PlaylistContainer> CreatePlaylist(string title, string listType, IEnumerable<string> itemRatingKeys) =>
+            await this.plexServerClient.CreatePlaylist(this.AccessToken, this.Uri.ToString(), this.MachineIdentifier, title, listType, itemRatingKeys);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="playlist"></param>
+        /// <param name="itemRatingKeys"></param>
+        /// <returns></returns>
+        public async Task<PlaylistContainer> AddPlaylistItems(PlaylistMetadata playlist, IEnumerable<string> itemRatingKeys) =>
+            await this.plexServerClient.AddPlaylistItems(this.AccessToken, this.Uri.ToString(), this.MachineIdentifier, playlist, itemRatingKeys);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="playlist"></param>
+        /// <returns></returns>
+        public async Task<MediaContainer> GetPlaylistItems(PlaylistMetadata playlist) =>
+            await this.plexServerClient.GetPlaylistItems(this.AccessToken, this.Uri.ToString(), playlist);
+
+        /// <summary>
         /// Get metadata for a given rating key.
         /// </summary>
         /// <param name="ratingKey">The rating key to get info from.</param>

--- a/Source/Plex.ServerApi/Clients/Interfaces/IPlexServerClient.cs
+++ b/Source/Plex.ServerApi/Clients/Interfaces/IPlexServerClient.cs
@@ -1,6 +1,7 @@
 namespace Plex.ServerApi.Clients.Interfaces
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Enums;
     using PlexModels.Hubs;
@@ -254,6 +255,29 @@ namespace Plex.ServerApi.Clients.Interfaces
         /// <param name="plexServerHost"></param>
         /// <returns></returns>
         Task<PlaylistContainer> GetPlaylists(string authToken, string plexServerHost);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="authToken"></param>
+        /// <param name="plexServerHost"></param>
+        /// <param name="title"></param>
+        /// <param name="listType"></param>
+        /// <param name="itemRatingsKeys"></param>
+        /// <returns></returns>
+        Task<PlaylistContainer> CreatePlaylist(string authToken, string plexServerHost, string hostIdentifier, string title, string listType, IEnumerable<string> itemRatingsKeys);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="authToken"></param>
+        /// <param name="plexServerHost"></param>
+        /// <param name="playlist"></param>
+        /// <param name="itemRatingsKeys"></param>
+        /// <returns></returns>
+        Task<PlaylistContainer> AddPlaylistItems(string authToken, string plexServerHost, string hostIdentifier, PlaylistMetadata playlist, IEnumerable<string> itemRatingsKeys);
+
+        Task<MediaContainer> GetPlaylistItems(string authToken, string plexServerHost, PlaylistMetadata playlist);
 
         /// <summary>
         ///

--- a/Source/Plex.ServerApi/Clients/PlexServerClient.cs
+++ b/Source/Plex.ServerApi/Clients/PlexServerClient.cs
@@ -368,6 +368,39 @@ namespace Plex.ServerApi.Clients
         public async Task<PlaylistContainer> GetPlaylists(string authToken, string plexServerHost) =>
             await this.FetchWithWrapper<PlaylistContainer>(plexServerHost, "playlists", authToken, HttpMethod.Get);
 
+
+        /// <inheritdoc/>
+        public async Task<PlaylistContainer> CreatePlaylist(string authToken, string plexServerHost, string hostIdentifier, string title, string listType, IEnumerable<string> itemRatingsKeys)
+        {
+            var queryParams = new Dictionary<string, string>
+            {
+                { "type", listType },
+                { "uri", $"server://{hostIdentifier}/com.plexapp.plugins.library/library/metadata/{string.Join(',', itemRatingsKeys)}" },
+                { "title", title },
+                { "smart", "0" },
+            };
+
+
+            return await this.FetchWithWrapper<PlaylistContainer>(plexServerHost, "playlists", authToken, HttpMethod.Post, queryParams);
+        }
+
+        /// <inheritdoc/>
+        public async Task<PlaylistContainer> AddPlaylistItems(string authToken, string plexServerHost, string hostIdentifier, PlaylistMetadata playlist, IEnumerable<string> itemRatingsKeys)
+        {
+            var queryParams = new Dictionary<string, string>
+            {
+                { "uri", $"server://{hostIdentifier}/com.plexapp.plugins.library/library/metadata/{string.Join(',', itemRatingsKeys)}" },
+            };
+
+
+            return await this.FetchWithWrapper<PlaylistContainer>(plexServerHost, playlist.Key, authToken, HttpMethod.Put, queryParams);
+        }
+
+        /// <inheritdoc/>
+        public async Task<MediaContainer> GetPlaylistItems(string authToken, string plexServerHost, PlaylistMetadata playlist) =>
+            await this.FetchWithWrapper<MediaContainer>(plexServerHost, playlist.Key, authToken, HttpMethod.Get);
+
+
         /// <inheritdoc/>
         public async Task<object> GetLogs(string authToken, string plexServerHost) =>
             await this

--- a/Source/Plex.ServerApi/PlexModels/Server/Playlists/Metadata.cs
+++ b/Source/Plex.ServerApi/PlexModels/Server/Playlists/Metadata.cs
@@ -15,7 +15,7 @@ namespace Plex.ServerApi.PlexModels.Server.Playlists
         public string ContentRating { get; set; }
 
         [JsonPropertyName("duration")]
-        public int Duration { get; set; }
+        public long Duration { get; set; }
 
         [JsonPropertyName("grandparentArt")]
         public string GrandparentArt { get; set; }


### PR DESCRIPTION
Adds three new methods on `IPlexServerClient` to support retrieving playlist items, creating playlists, and adding items to a playlist.  A new sample is included that shows how to use these new methods to split a large playlist into smaller playlists.  This is useful to overcome the 24h sync limit in PlexAmp large playlists.